### PR TITLE
Add tournament, matches, team & player routes

### DIFF
--- a/config/allowedOrigins.js
+++ b/config/allowedOrigins.js
@@ -1,5 +1,4 @@
 const allowedOrigins = [
-    'http://localhost:3000',
     'https://www.futheadpvtltd.com',
     'https://futheadpvtltd.com'
 ];

--- a/config/corsOptions.js
+++ b/config/corsOptions.js
@@ -3,11 +3,12 @@ const allowedOrigins = require('./allowedOrigins');
 const corsOptions = {
     origin: (origin, callback) => {
         // !origin is allowed for postman or other desktop applications that do not send origin
-        if (allowedOrigins.indexOf(origin) !== -1 || !origin) {
-            callback(null, true);
-        } else {
-            callback(new Error('Not allowed by CORS'));
-        }
+        // if (allowedOrigins.indexOf(origin) !== -1 || !origin) {
+        //     callback(null, true);
+        // } else {
+        //     callback(new Error('Not allowed by CORS'));
+        // }
+        callback(null, true);
     },
     credentials: true,
     optionsSuccessStatus: 200 // older browsers, smart TVs may have a problem with 204

--- a/controllers/matchesController.js
+++ b/controllers/matchesController.js
@@ -1,0 +1,142 @@
+const bcrypt = require('bcrypt');
+const Match = require('../models/Match');
+const Stage = require('../models/Stage');
+const Tournament = require('../models/Tournament');
+const MatchCounter = require('../models/MatchCounter');
+const asyncHandler = require('express-async-handler');
+
+// @desc Get all tournaments
+// @route GET /tournaments
+// @access Public
+const getMatchesByQuery = asyncHandler( async (req, res) => {
+    const { player, player1, player2 } = req.query;
+
+    let matches;
+    if ( player1 !== undefined && player2 !== undefined ) {
+        matches = await Match.find({
+            $or: [
+              { $and: [{ 'scoreline.home.player': player1 }, { 'scoreline.away.player': player2 }] },
+              { $and: [{ 'scoreline.home.player': player2 }, { 'scoreline.away.player': player1 }] }
+            ]
+        }).sort({ identifier: -1 }).lean().exec();
+    } else if ( player !== undefined ) {
+        matches = await Match.find({ $or: [{ 'scoreline.home.player': player }, { 'scoreline.away.player': player }] }).sort({ identifier: -1 }).lean().exec();
+    } else {
+        matches = await Match.find().lean().exec();
+    }
+
+    if(!matches?.length) {
+        return res.status(400).json({ message: 'No matches found' });
+    }
+
+    res.json(matches);
+});
+
+// @desc Create a tournament
+// @route POST /tournaments
+// @access Private
+const addNewMatch = asyncHandler( async(req, res) => {
+    const { stageId, tournamentId, scoreline } = req.body;
+    let teamsIncluded = req.body.teamsIncluded;
+    let identifier = req.body.identifier;
+
+    const stage = await Stage.findById(stageId).lean().exec();
+    if (!stage) {
+        return res.status(400).json({ message: `Invalid StageId ${stageId}` });
+    }
+
+    const tournament = await Tournament.findById(tournamentId).lean().exec();
+    if (!tournament) {
+        return res.status(400).json({ message: `Invalid TournamentId ${tournamentId}` });
+    }
+    if (tournament.participants[0].team) {
+        teamsIncluded = teamsIncluded ?? true;
+    }
+    
+    if (stage.tournament !== tournament.name) {
+        return res.status(400).json({ message: `Stage (ID: ${stageId}) doesn't belong to Tournament (ID: ${tournamentId})` });
+    }
+    let homeCheck = false;
+    let awayCheck = false;
+    for (const participant of tournament.participants) {
+        if (scoreline.home.player === participant.player) {
+            if (teamsIncluded) {
+                if (scoreline.home.team === participant.team) {
+                    homeCheck = true;
+                    continue;
+                }
+            } else {
+                homeCheck = true;
+                continue;
+            }
+        }
+        if (scoreline.away.player === participant.player) {
+            if (teamsIncluded) {
+                if (scoreline.away.team === participant.team) {
+                    awayCheck = true;
+                }
+            } else {
+                awayCheck = true;
+            }
+        }
+        if (homeCheck && awayCheck) {
+            break;
+        }
+    }
+
+    if (!homeCheck || !awayCheck) {
+        return res.status(400).json({ message: `Participants don't belong to the tournament` });
+    }
+
+    let winner = null;
+    if (scoreline.home.score !== scoreline.away.score) {
+        winner = scoreline.home.score > scoreline.away.score ? scoreline.home : scoreline.away;
+    }
+
+    const matchCount = await MatchCounter.findById(identifier).lean();
+    if (matchCount) {
+        const updatedMatchCount = await MatchCounter.findByIdAndUpdate(identifier, { count: matchCount.count+1 }, { new: true });
+        identifier = identifier + '_' + (updatedMatchCount.count > 9 ? updatedMatchCount.count : ('0' + updatedMatchCount.count));
+    } else {
+        const createdMatchCount = await MatchCounter.create({ _id: identifier, count: 1 });
+        identifier = identifier + '_01';
+    }
+
+    const matchObject = {
+        identifier,
+        stage: {
+            _id: stageId,
+            name: stage.type
+        },
+        tournament: {
+            _id: tournamentId,
+            name: tournament.name
+        },
+        scoreline,
+        winner
+    };
+    const match = await Match.create(matchObject);
+
+    if (match) {
+        res.status(201).json({ message: `New match added in ${tournament.name} ${stage.type}`});
+    } else {
+        res.status(400).json({ message: 'Invalid match data received' });
+    }
+});
+
+const authenticate = asyncHandler( async(req, res) => {
+    const { password } = req.body;
+    const hashedPassword = decodeURIComponent(process.env.ADMIN_PASSWORD);
+    const isPasswordCorrect = bcrypt.compareSync(password, hashedPassword);
+    if (isPasswordCorrect) {
+        res.status(201).json({ message: 'Authentication Successfull!'});
+    } else {
+        res.status(400).json({ message: 'Incorrect Password' });
+    }
+});
+
+module.exports = {
+    getMatchesByQuery,
+    addNewMatch,
+    authenticate,
+};

--- a/controllers/playersController.js
+++ b/controllers/playersController.js
@@ -1,12 +1,20 @@
 const Player = require('../models/Player');
+const Match = require('../models/Match');
+const Tournament = require('../models/Tournament');
 const asyncHandler = require('express-async-handler');
 
 // @desc Get all players
 // @route GET /players
 // @access Public
 const getAllPlayers = asyncHandler( async (req, res) => {
-    const players = await Player.find().lean();
-    if(!players?.length) {
+    let player = null;
+    if (req.query.onlyActive === 'true') {
+        const query = { activeStatus: 'ACTIVE' };
+        players = await Player.find(query).select('-activeStatus').lean().exec();
+    } else {
+        players = await Player.find().lean();
+    }
+    if (!players?.length) {
         return res.status(400).json({ message: 'No players found' })
     }
     res.json(players);
@@ -24,21 +32,21 @@ const addNewPlayer = asyncHandler( async (req, res) => {
     }
 
     // Check for duplicates
-    const duplicate = await Player.findOne({ identifier }).lean().exec();
+    const duplicate = await Player.findById(identifier).lean().exec();
 
     if(duplicate) {
         return res.status(409).json({ message: 'Duplicate player identifier' });
     }
 
-    const playerObject = { identifier, fullname, activeStatus };
+    const playerObject = { _id: identifier, fullname, activeStatus };
 
-    // Create and store new user
+    // Create and store new player
     const player = await Player.create(playerObject);
 
     if (player) {
-        res.status(201).json({ message: `New user ${identifier} created`});
+        res.status(201).json({ message: `New player ${identifier} created`});
     } else {
-        res.status(400).json({ message: 'Invalid user data received' });
+        res.status(400).json({ message: 'Invalid player data received' });
     } 
 });
 
@@ -46,37 +54,154 @@ const addNewPlayer = asyncHandler( async (req, res) => {
 // @route PATCH /players
 // @access Private
 const updatePlayer = asyncHandler( async (req, res) => {
-    const { id, identifier, fullname, activeStatus } = req.body;
+    const { identifier, fullname, activeStatus } = req.body;
 
     // Confirming data
     if(!identifier || !fullname || !activeStatus) {
         return res.status(400).json({ message: 'Missing required fields' });
     }
 
-    const player = await Player.findById(id).exec();
+    const player = await Player.findById(identifier).exec();
 
     if (!player) {
-        return res.status(400).json({ message: "User not found"});
+        return res.status(400).json({ message: "Player not found"});
     }
 
-    // Check for duplicate
-    const duplicate = await Player.findOne({ identifier }).lean().exec();
-    // Restrict update if the username is a duplicate of a different player 
-    if (duplicate && duplicate?._id.toString() !== id) {
-        return res.status(409).json({ message: 'Duplicate Identifier'});
-    }
-    // Allow if the identifier is of the same player
-    player.identifier = identifier;
     player.fullname = fullname;
     player.activeStatus = activeStatus;
 
     const updatedPlayer = await player.save();
 
-    res.json({ message: `${updatedPlayer.identifier} updated`});
+    res.json({ message: `${updatedPlayer._id} updated`});
 })
+
+const getPlayerById = asyncHandler( async (req, res) => {
+    const player = await Player.findById(req.params.playerId).lean();
+    if (!player) {
+        return res.status(400).json({ message: "Player not found"});
+    }
+    if (req.query.includeTourDetails !== 'true') {
+        return res.json(player);
+    }
+    const tournaments = await Tournament.find().lean();
+    let toursPlayed = 0;
+    let toursWon = 0;
+    let tourFinals = 0;
+    let trophiesWon = [];
+    let finalsReached = [];
+    if(tournaments && tournaments.length) {
+        for (const tournament of tournaments) {
+            if (tournament.status === 'ABANDONED') {
+                continue;
+            }
+            if (tournament.winner && tournament.winner.player === req.params.playerId) {
+                toursPlayed = toursPlayed + 1;
+                toursWon = toursWon + 1;
+                tourFinals = tourFinals + 1;
+                trophiesWon.push(tournament.name);
+            } else if (tournament.runnersUp && tournament.runnersUp.player === req.params.playerId) {
+                toursPlayed = toursPlayed + 1;
+                tourFinals = tourFinals + 1;
+                finalsReached.push(tournament.name);
+            } else {
+                for (const participantsData of tournament.participants) {
+                    if (participantsData.player === req.params.playerId) {
+                        toursPlayed = toursPlayed + 1;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    const tournamentsData = {
+        played: toursPlayed,
+        won: toursWon,
+        finalist: tourFinals,
+        trophies: trophiesWon,
+        finals: finalsReached,
+    }
+    player.tournamentsData = tournamentsData;
+    res.json(player);
+});
+
+const getMatchStatsByPlayerId = asyncHandler( async(req, res) => {
+    const playerId = req.params.playerId;
+    matches = await Match.find({
+        $or: [
+            { 'scoreline.home.player': playerId },
+            { 'scoreline.away.player': playerId }
+        ]
+    }).sort({ identifier: -1 }).lean().exec();
+
+    if (!matches) {
+        return res.status(400).json({ message: `No matches found for playerId: ${playerId}`});
+    }
+
+    const totalMatchesN = matches.length;
+    let matchesWonN = 0, matchesLostN = 0, matchesDrawnN = 0, nGA = 0, nGF = 0;
+
+    const playerTeamMap = new Map();
+
+    for (const match of matches) {
+        if (!match.winner) {
+            matchesDrawnN = matchesDrawnN + 1;
+        } else if (match.winner.player === playerId) {
+            matchesWonN = matchesWonN + 1;
+        } else {
+            matchesLostN = matchesLostN + 1;
+        }
+
+        if (match.scoreline.home.player === playerId) {
+
+            const tempKey = match.scoreline.home.team;
+            if (match.scoreline.home.team) {
+                if (playerTeamMap.has(tempKey)) {
+                    // Key exists, increment its value
+                    const currentValue = playerTeamMap.get(tempKey);
+                    playerTeamMap.set(tempKey, currentValue + 1);
+                } else {
+                    // Key does not exist, set value to 1
+                    playerTeamMap.set(tempKey, 1);
+                }
+            }
+
+            nGF = nGF + match.scoreline.home.score;
+            nGA = nGA + match.scoreline.away.score;
+        } else {
+            nGF = nGF + match.scoreline.away.score;
+            nGA = nGA + match.scoreline.home.score;
+        }
+    }
+
+    const favTeam = {
+        id: null,
+        value: 0,
+    }
+    for (const [key, value] of playerTeamMap.entries()) {
+        if (value > favTeam.value) {
+            favTeam.id = key;
+            favTeam.value = value;
+        }
+    }
+
+    const responseObject = {
+        played: totalMatchesN,
+        winPercent: ((matchesWonN/totalMatchesN) * 100).toFixed(2),
+        favTeam: favTeam.id,
+        won: matchesWonN,
+        drawn: matchesDrawnN,
+        lost: matchesLostN,
+        goalsFor: nGF,
+        goalsAgainst: nGA,
+        goalDifference: nGF - nGA,
+    }
+    res.json(responseObject);
+});
 
 module.exports = {
     getAllPlayers,
     addNewPlayer,
-    updatePlayer
+    updatePlayer,
+    getPlayerById,
+    getMatchStatsByPlayerId
 };

--- a/controllers/teamsController.js
+++ b/controllers/teamsController.js
@@ -1,0 +1,82 @@
+const Team = require('../models/Team');
+const asyncHandler = require('express-async-handler');
+
+// @desc Get all teams
+// @route GET /teams
+// @access Public
+const getAllTeams = asyncHandler( async (req, res) => {
+    const teams = await Team.find().lean();
+    if(!teams?.length) {
+        return res.status(400).json({ message: 'No teams found' })
+    }
+    res.json(teams);
+});
+
+// @desc Add new team
+// @route POST /teams
+// @access Private
+const addNewTeam = asyncHandler( async (req, res) => {
+    const { identifier, fullname } = req.body;
+
+    // Confirming data
+    if(!identifier || !fullname) {
+        return res.status(400).json({ message: 'Missing required fields' });
+    }
+
+    // Check for duplicates
+    const duplicate = await Team.findOne({ _id: identifier }).lean().exec();
+
+    if(duplicate) {
+        return res.status(409).json({ message: 'Duplicate player identifier' });
+    }
+
+    const teamObject = { _id: identifier, fullname };
+
+    // Create and store new team
+    const team = await Team.create(teamObject);
+
+    if (team) {
+        res.status(201).json({ message: `New team ${fullname} created`});
+    } else {
+        res.status(400).json({ message: 'Invalid team data received' });
+    } 
+});
+
+// @desc Update a team
+// @route PATCH /teams
+// @access Private
+const updateTeam = asyncHandler( async (req, res) => {
+    // const { id, identifier, fullname, activeStatus } = req.body;
+
+    // // Confirming data
+    // if(!identifier || !fullname || !activeStatus) {
+    //     return res.status(400).json({ message: 'Missing required fields' });
+    // }
+
+    // const player = await Player.findById(id).exec();
+
+    // if (!player) {
+    //     return res.status(400).json({ message: "User not found"});
+    // }
+
+    // // Check for duplicate
+    // const duplicate = await Player.findOne({ identifier }).lean().exec();
+    // // Restrict update if the username is a duplicate of a different player 
+    // if (duplicate && duplicate?._id.toString() !== id) {
+    //     return res.status(409).json({ message: 'Duplicate Identifier'});
+    // }
+    // // Allow if the identifier is of the same player
+    // player.identifier = identifier;
+    // player.fullname = fullname;
+    // player.activeStatus = activeStatus;
+
+    // const updatedPlayer = await player.save();
+
+    // res.json({ message: `${updatedPlayer.identifier} updated`});
+})
+
+module.exports = {
+    getAllTeams,
+    addNewTeam,
+    updateTeam
+};

--- a/controllers/tournamentsController.js
+++ b/controllers/tournamentsController.js
@@ -1,0 +1,155 @@
+const Tournament = require('../models/Tournament');
+const Player = require('../models/Player');
+const Team = require('../models/Team');
+const Stage = require('../models/Stage');
+const asyncHandler = require('express-async-handler');
+
+// @desc Get all tournaments
+// @route GET /tournaments
+// @access Public
+const getAllTournaments = asyncHandler( async (req, res) => {
+    const tournaments = await Tournament.find().lean().exec();
+    if (!tournaments?.length) {
+        return res.status(400).json({ message: 'No tournaments found' });
+    }
+    res.json(tournaments);
+});
+
+// @desc Create a tournament
+// @route POST /tournaments
+// @access Private
+const createNewTournament = asyncHandler( async(req, res) => {
+    // TO-DO: Remove after auto-increment has been implemented
+    const {
+        name,
+        format,
+        status,
+        stages,
+        participants,
+        winner,
+        runnersUp,
+        teamsIncluded,
+    } = req.body;
+
+    /**
+     * CHECKING DATA
+     * Serial Number is an auto-increment field
+     * participants must never be empty
+     * Completed Tournaments must have winners and runnersUp
+     * Each participant, winner and runnersUp must have atleast playerId (teamId is optional)
+     * each playerId/teamId 
+     */
+    if (!name || !Array.isArray(participants) || !participants.length) {
+        return res.status(400).json({ message: 'Missing required fields' });
+    }
+    if (status == "COMPLETED" && (!winner || !runnersUp)) {
+        return res.status(400).json({ message: 'Missing required fields for a completed tournament' });
+    }
+    if (status == "COMPLETED" && (!winner.player || !runnersUp.player)) {
+        return res.status(400).json({ message: 'Each participant must have a player' });
+    }
+    const players = await Player.find().select('_id').lean();
+    const playerIds = await players.map(obj => obj._id);
+
+    if (status == "COMPLETED" && !playerIds.includes(winner.player)) {
+        return res.status(400).json({ message: 'Invalid Winner\'s Player ID' });
+    }
+
+    if (status == "COMPLETED" && !playerIds.includes(runnersUp.player)) {
+        return res.status(400).json({ message: 'Invalid Runner Up\'s Player ID' });
+    }
+
+    let teamIds = [];
+
+    if (teamsIncluded) {
+        if (status == "COMPLETED" && (!winner.team || !runnersUp.team)) {
+            return res.status(400).json({ message: 'Each participant must have a team' });
+        }
+        const teams = await Team.find().select('_id').lean();
+        teamIds = await teams.map(obj => obj._id);
+    
+        if (status == "COMPLETED" && !teamIds.includes(winner.team)) {
+            return res.status(400).json({ message: 'Invalid Winner\'s Team ID' });
+        }
+    
+        if (status == "COMPLETED" && !teamIds.includes(runnersUp.team)) {
+            return res.status(400).json({ message: 'Invalid Runner Up\'s Team ID' });
+        }
+    }
+
+    for (const participant of participants) {
+        if (!participant.player) {
+            return res.status(400).json({ message: 'Each participant must have a player' });
+        }
+        if (!playerIds.includes(participant.player)) {
+            return res.status(400).json({ message: 'Invalid Participant\'s Player ID' });
+        }
+        if (teamsIncluded && !teamIds.includes(participant.team)) {
+            return res.status(400).json({ message: 'Invalid Participant\'s Team ID' });
+        }
+    }
+
+    // Check for duplicates
+    const duplicate = await Tournament.findOne({ name }).lean().exec();
+    if(duplicate) {
+        return res.status(409).json({ message: 'Duplicate tournament name' });
+    }
+
+    const stageIds = [];
+    // TO-DO: Add Stages Creation
+    if (stages && stages.length !== 0) {
+        for (const stage of stages) {
+            const stageObject = {
+                type: stage,
+                tournament: name,
+            }
+            const createdStage = await Stage.create(stageObject);
+            stageIds.push(createdStage._id);
+        }
+    }
+
+    const tournamentObject = { name, format, status, participants, winner, runnersUp, stages: stageIds };
+
+    // Create and store new user
+    const tournament = await Tournament.create(tournamentObject);
+
+    if (tournament) {
+        res.status(201).json({ message: `New tournament ${name} created`});
+    } else {
+        res.status(400).json({ message: 'Invalid tournament data received' });
+    } 
+});
+
+const getTournamentById = asyncHandler( async (req, res) => {
+    const tournament = await Tournament.findById(req.params.tournamentId).lean();
+    if (!tournament) {
+        return res.status(400).json({ message: `Invalid TournamentId ${tournamentId}` });
+    }
+
+    let stageDetails = [];
+    if(tournament.stages && tournament.stages.length !== 0) {
+        for (const stage of tournament.stages) {
+            const stageData = await Stage.findById(stage).lean();
+            const stageObject = {
+                id: stage,
+                type: stageData.type,
+            }
+            stageDetails.push(stageObject);
+            tournament.stages = stageDetails;
+        }
+    }
+
+    if(req.query.getOptions === 'true') {
+        let optionsObject = { stages: stageDetails, players: tournament.participants};
+
+        return res.json(optionsObject);
+    }
+
+    res.json(tournament);
+});
+
+module.exports = {
+    getAllTournaments,
+    createNewTournament,
+    getTournamentById
+};

--- a/models/Counter.js
+++ b/models/Counter.js
@@ -1,0 +1,43 @@
+const mongoose = require('mongoose');
+
+const counterSchema = new mongoose.Schema({
+    _id: {
+        type: String,
+        required: true
+    },
+    count: {
+        type: Number,
+        default: 0
+    }
+});
+
+counterSchema.index({ _id: 1, seq: 1 }, { unique: true })
+
+const counterModel = mongoose.model('counter', counterSchema);
+
+const autoIncrementModel = async(modelName, fieldName, doc, next) => {
+    try {
+        /**
+         * modelName is the key (ID) here
+         * $inc indicates what field to increment and by how much
+         * new: return the new value
+         * upsert: create document if it doesn't exist
+         */
+        const counterObject = await counterModel.findByIdAndUpdate(
+            modelName,
+            { $inc: { count: 1 } },
+            { new: true, upsert: true },
+        );
+
+        if (counterObject) {
+            if (modelName == 'Tournament') {
+                doc[fieldName] = counterObject.count;
+            }
+            next();
+        }
+    } catch (error) {
+        next(error);
+    }
+};
+
+module.exports = autoIncrementModel;

--- a/models/Match.js
+++ b/models/Match.js
@@ -1,0 +1,69 @@
+const mongoose = require('mongoose');
+
+const matchSchema = new mongoose.Schema({
+    identifier: {
+        type: String,
+        required: true,
+        unique: true,
+    },
+    scoreline: {
+        home: {
+            player: {
+                type: String,
+                ref: 'Player'
+            },
+            team: {
+                type: String,
+                ref: 'Team'
+            },
+            score: {
+                type: Number,
+            }
+        },
+        away:  {
+            player: {
+                type: String,
+                ref: 'Player'
+            },
+            team: {
+                type: String,
+                ref: 'Team'
+            },
+            score: {
+                type: Number,
+            }
+        },
+    },
+    winner: {
+        player: {
+            type: String,
+            ref: 'Player'
+        },
+        team: {
+            type: String,
+            ref: 'Team'
+        }
+    },
+    stage: {
+        _id: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Stage',
+            required: true,
+        },
+        name: {
+            type: String
+        }
+    },
+    tournament: {
+        _id: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Tournament',
+            required: true,
+        },
+        name: {
+            type: String
+        }
+    }
+});
+
+module.exports = mongoose.model('Match', matchSchema);

--- a/models/MatchCounter.js
+++ b/models/MatchCounter.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const matchCounterSchema = new mongoose.Schema({
+    _id: {
+        type: String,
+        required: true,
+    },
+    count: {
+        type: Number,
+        default: 0,
+    }
+});
+
+module.exports = mongoose.model('MatchCounter', matchCounterSchema);

--- a/models/Player.js
+++ b/models/Player.js
@@ -1,10 +1,9 @@
 const mongoose = require('mongoose');
 
-const PlayerSchema = new mongoose.Schema({
-    identifier: {
+const playerSchema = new mongoose.Schema({
+    _id: {
         type: String,
         required: true,
-        unique: true,
     },
     fullname: {
         type: String,
@@ -17,4 +16,4 @@ const PlayerSchema = new mongoose.Schema({
     }
 });
 
-module.exports = mongoose.model('Player', PlayerSchema);
+module.exports = mongoose.model('Player', playerSchema);

--- a/models/Stage.js
+++ b/models/Stage.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const stageSchema = new mongoose.Schema({
+    type: {
+        type: String,
+        enum: ['GROUP_STAGE', 'LEAGUE', "QUARTER_FINAL", "SEMI_FINAL", "FINAL"],
+        required: true
+    },
+    tournament: {
+        type: String,
+        required: true
+    }
+});
+
+module.exports = mongoose.model('Stage', stageSchema);

--- a/models/Team.js
+++ b/models/Team.js
@@ -1,15 +1,15 @@
 const mongoose = require('mongoose');
 
-const TeamSchema = new mongoose.Schema({
-    identifier: {
-        type: String,
-        required: true,
-        unique: true,
-    },
-    fullname: {
+const teamSchema = new mongoose.Schema({
+    _id: {
         type: String,
         required: true
     },
+    fullname: {
+        type: String,
+        required: true,
+        unique: true
+    },
 });
 
-module.exports = mongoose.model('Team', TeamSchema);
+module.exports = mongoose.model('Team', teamSchema);

--- a/models/Tournament.js
+++ b/models/Tournament.js
@@ -1,0 +1,68 @@
+const mongoose = require('mongoose');
+const autoIncrementModel = require('./Counter');
+
+const tournamentSchema = new mongoose.Schema({
+    serialNumber: {
+        type: Number,
+    },
+    name: {
+        type: String,
+        required: true,
+        unique: true
+    },
+    format: {
+        type: String,
+        enum: ['GROUP & KNOCKOUT', 'KNOCKOUT', 'LEAGUE'],
+        default: 'GROUP & KNOCKOUT'
+    },
+    status: {
+        type: String,
+        enum: ['FUTURE', 'INPROGRESS', 'COMPLETED', 'ABANDONED'],
+        defult: 'FUTURE'
+    },
+    stages: [{
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Stage'
+    }],
+    participants: [{
+        player: {
+            type: mongoose.Schema.Types.String,
+            ref: 'Player',
+            required: true
+        },
+        team: {
+            type: mongoose.Schema.Types.String,
+            ref: 'Team',
+        }
+    }],
+    winner: {
+        player: {
+            type: mongoose.Schema.Types.String,
+            ref: 'Player'
+        },
+        team: {
+            type: mongoose.Schema.Types.String,
+            ref: 'Team'
+        }
+    },
+    runnersUp: {
+        player: {
+            type: mongoose.Schema.Types.String,
+            ref: 'Player'
+        },
+        team: {
+            type: mongoose.Schema.Types.String,
+            ref: 'Team'
+        }
+    },
+});
+
+tournamentSchema.pre('save', function (next) {
+    if (!this.isNew) {
+        next();
+        return;
+    }
+    autoIncrementModel('Tournament', 'serialNumber', this, next);
+});
+
+module.exports = mongoose.model('Tournament', tournamentSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.0",
+        "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "date-fns": "^2.30.0",
@@ -81,10 +82,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q=="
+      "version": "20.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.8.tgz",
+      "integrity": "sha512-eajsR9aeljqNhK028VG0Wuw+OaY5LLxYmxeoXynIoE6jannr9/Ucd1LL0hSSoafk5LTYG+FfqsyGt81Q6Zkybw=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.0",
@@ -210,6 +220,11 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -264,9 +279,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
-      "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -1030,11 +1045,11 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
-      "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dependencies": {
-        "bson": "^5.2.0",
+        "bson": "^5.4.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -1042,15 +1057,23 @@
         "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.3"
+        "@mongodb-js/saslprep": "^1.1.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
         "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
           "optional": true
         },
         "mongodb-client-encryption": {
@@ -1071,20 +1094,20 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.1.0.tgz",
-      "integrity": "sha512-shoo9z/7o96Ojx69wpJn65+EC+Mt3q1SWTducW+F2Y4ieCXo0lZwpCZedgC841MIvJ7V8o6gmzoN1NfcnOTOuw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.5.0.tgz",
+      "integrity": "sha512-FpOWOb0AJuaVcplmEyIJ2eCbVGe4gOoniPD+pmft5BrGrNrsFcnYXlERdXtBApGHMHPwD7WbxTyhCbUNr72F3Q==",
       "dependencies": {
-        "bson": "^5.2.0",
+        "bson": "^5.4.0",
         "kareem": "2.5.1",
-        "mongodb": "5.3.0",
+        "mongodb": "5.8.1",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
         "sift": "16.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1467,18 +1490,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^5.1.0",
+    "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "date-fns": "^2.30.0",

--- a/routes/matchRoutes.js
+++ b/routes/matchRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const matchesController = require('../controllers/matchesController');
+
+router.route('/')
+    .get(matchesController.getMatchesByQuery)
+    .post(matchesController.addNewMatch)
+
+router.route('/authenticate').post(matchesController.authenticate)
+
+module.exports = router;

--- a/routes/playerRoutes.js
+++ b/routes/playerRoutes.js
@@ -6,5 +6,8 @@ router.route('/')
     .get(playersController.getAllPlayers)
     .post(playersController.addNewPlayer)
     .patch(playersController.updatePlayer)
+    
+router.route('/:playerId').get(playersController.getPlayerById)
+router.route('/:playerId/match_stats').get(playersController.getMatchStatsByPlayerId)
 
 module.exports = router;

--- a/routes/teamRoutes.js
+++ b/routes/teamRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const teamsController = require('../controllers/teamsController');
+
+router.route('/')
+    .get(teamsController.getAllTeams)
+    .post(teamsController.addNewTeam)
+    .patch(teamsController.updateTeam)
+
+module.exports = router;

--- a/routes/tournamentRoutes.js
+++ b/routes/tournamentRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const tournamentsController = require('../controllers/tournamentsController');
+
+router.route('/')
+    .get(tournamentsController.getAllTournaments)
+    .post(tournamentsController.createNewTournament)
+    // .patch(tournamentsController.updateTournament)
+
+router.route('/:tournamentId').get(tournamentsController.getTournamentById)
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -28,6 +28,9 @@ app.use('/', express.static(path.join(__dirname, 'public')));
 app.use('/', require('./routes/root'));
 app.use('/users', require('./routes/userRoutes'));
 app.use('/players', require('./routes/playerRoutes'));
+app.use('/teams', require('./routes/teamRoutes'));
+app.use('/tournaments', require('./routes/tournamentRoutes'));
+app.use('/matches', require('./routes/matchRoutes'));
 
 app.all('*', (req, res) => {
     res.status(404);


### PR DESCRIPTION
## List of Changes
- **Temporary changes to allow all CORS origins**

- **Added new Models**:
Tournament
Stage
Match
Counter (auto increment tournament counter)
Match Counter (counts matches in each stage to maintain match_identifier field)

- **Update existing models**
Team (id is updated to type String instead of ObjectId viz. 12-byte identifier)
Player (id is updated to type String instead of ObjectId viz. 12-byte identifier)

- **Added new player routes & controllers for**: 
get one player's tournament data
get one player's match stats

- **Added teams routes & controllers for**: 
get all teams
add one team
update one team 

- **Added tournament routes**: 
get all tournaments
add one tournament

- **Added match routes**: 
add one match
get matches by query
authenticate
